### PR TITLE
Unassign Skill Points button crashes every time

### DIFF
--- a/PlugY/D2functions.cpp
+++ b/PlugY/D2functions.cpp
@@ -470,7 +470,7 @@ FCT_ASM ( D2GetClient_111 )
 
 FCT_ASM( D2SetSkillBaseLevelOnClient_114 )
     PUSH EBX
-    PUSH EBX
+    PUSH EDX
     PUSH ESI
     PUSH DWORD PTR SS : [ESP + 0x14]
     PUSH DWORD PTR SS : [ESP + 0x14]

--- a/PlugY/D2wrapper.cpp
+++ b/PlugY/D2wrapper.cpp
@@ -231,7 +231,14 @@ void freeCustomLibraries()
 		dll->release();
 		freeLibrary(dll->offset);
 		nextDll = dll->nextDll;
-		D2FogMemDeAlloc(dll,__FILE__,__LINE__,0);
+		if (version_D2Game == V114d)
+		{
+			delete dll;
+		}
+		else
+		{
+			D2FogMemDeAlloc(dll, __FILE__, __LINE__, 0);
+		}
 		dll = nextDll;
 	}
 }


### PR DESCRIPTION
Pushing EBX was probably a typing error.  EDX should have been pushed to save the value in ESI.   This was causing the crash.