### PR TITLE
Crash when freeing custom libraries

### DIFF
--- a/PlugY/D2wrapper.cpp
+++ b/PlugY/D2wrapper.cpp
@@ -231,7 +231,14 @@ void freeCustomLibraries()
 		dll->release();
 		freeLibrary(dll->offset);
 		nextDll = dll->nextDll;
-		D2FogMemDeAlloc(dll,__FILE__,__LINE__,0);
+		if (version_D2Game == V114d)
+		{
+			delete dll;
+		}
+		else
+		{
+			D2FogMemDeAlloc(dll, __FILE__, __LINE__, 0);
+		}
 		dll = nextDll;
 	}
 }


### PR DESCRIPTION
Since the parameter 'dll' was created using c++ new we will remove it using c++ delete.  The D2FogMemDeAlloc in version 1.14d is finicky and works sometime and others it causes crashes.   I found another part of the code where halifax pretty much used the same way to deal with D2FogMemDeAlloc.  It would probably not hurt to change all the code where this is used but lets keep it how it was for previous versions of Diablo 2