### PR TITLE
Fix encoding of text file created by /listcube command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@
 **/*.VC.VC.opendb
 **/UpgradeLog*
 /PlugYRun/PlugYRun.aps
+**/Debug/
+/PlugY/Backup/

--- a/PlugY/NewInterface_CubeListing.cpp
+++ b/PlugY/NewInterface_CubeListing.cpp
@@ -283,7 +283,7 @@ void listAllCubeFormula()
 	D2FogGetSavePath(filename, MAX_PATH);
 	strcat(filename, CUBEFORMULA_FILE);
 
-	FILE* file = fopen(filename, "w");
+	FILE* file = fopen(filename, "wt, ccs=UTF-8");
 	if (!file)
 	{
 		log_msg("Failed to open save file.\n");


### PR DESCRIPTION
File descriptor was opened in ANSI encoding but you're writing WCHAR in it, this breaks if buffer data is not English (ANSI).

Tested by running D2 in Russian and executing the command.